### PR TITLE
Add React Native emulator instructions

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,0 +1,6 @@
+import React from 'react';
+import HelloWorld from './src/components/HelloWorld';
+
+export default function App() {
+  return <HelloWorld />;
+}

--- a/README.md
+++ b/README.md
@@ -1,2 +1,39 @@
-# VibeCodingPractice
-Learning Code Management via Agentic AI
+# VibeCodingPractice React Native Scaffold
+
+This repository contains the foundation for a React Native application. The
+current version simply displays `Hello World` and includes a minimal testing
+setup using Jest. The project is intended to grow into a more mature
+application with internal APIs, a database, and user preference storage.
+
+## Tool Versions
+- React `18.2.0`
+- React Native `0.73.4`
+- Jest `29.6.0`
+
+## Getting Started
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Run the tests:
+   ```bash
+   npm test
+   ```
+3. Launch the Expo development server with a web-based emulator:
+   ```bash
+   npm start
+   ```
+   This opens Expo DevTools in your browser. Choose the **Web** option to host
+   the app in an online emulator. You can also scan the QR code with the Expo Go
+   mobile app to view it on a real device.
+
+## File Structure
+- `App.js` – entry component rendering `HelloWorld`
+- `index.js` – registers the app
+- `app.json` – basic app metadata
+- `src/components/HelloWorld.js` – simple component displaying the greeting
+- `__tests__/App.test.js` – Jest snapshot test
+
+## Notes
+The environment used to generate this scaffold does not include downloaded
+`node_modules`, so running `npm install` is required before tests will pass.

--- a/__tests__/App.test.js
+++ b/__tests__/App.test.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import App from '../App';
+
+describe('App', () => {
+  it('renders hello world', () => {
+    const tree = renderer.create(<App />).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/app.json
+++ b/app.json
@@ -1,0 +1,4 @@
+{
+  "name": "VibeCodingApp",
+  "displayName": "VibeCodingApp"
+}

--- a/index.js
+++ b/index.js
@@ -1,0 +1,5 @@
+import {AppRegistry} from 'react-native';
+import App from './App';
+import {name as appName} from './app.json';
+
+AppRegistry.registerComponent(appName, () => App);

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,0 +1,1 @@
+import 'react-native-gesture-handler/jestSetup';

--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "vibecodingapp",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "test": "jest",
+    "start": "expo start --web"
+  },
+  "dependencies": {
+    "react": "18.2.0",
+    "react-native": "0.73.4"
+  },
+  "devDependencies": {
+    "expo": "^50.0.0",
+    "@testing-library/react-native": "13.4.0",
+    "react-test-renderer": "18.2.0",
+    "jest": "29.6.0"
+  },
+  "jest": {
+    "preset": "react-native",
+    "setupFiles": ["./jest.setup.js"]
+  }
+}

--- a/src/components/HelloWorld.js
+++ b/src/components/HelloWorld.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import { Text, View } from 'react-native';
+
+export default function HelloWorld() {
+  return (
+    <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+      <Text>Hello World</Text>
+    </View>
+  );
+}


### PR DESCRIPTION
## Summary
- add Expo as dev dependency and start script
- update README with instructions for running Expo web emulator

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851ff19dd00832cb823ff4e20796965