### PR TITLE
Add Expo hello world demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,25 @@
 # VibeCodingPractice
 Learning Code Management via Agentic AI
+
+## Expo Hello World Demo
+
+A minimal React Native project using [Expo](https://expo.dev/) is located in the `expo-hello-world` directory. The app simply displays **Hello World**.
+
+### Running locally
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+   inside the `expo-hello-world` folder.
+2. Start the Expo development server:
+   ```bash
+   npx expo start
+   ```
+   From the prompts, you can choose to open it on web or with a mobile device using the Expo Go app.
+
+### View online
+To view the app online without downloading, open this Snack link:
+
+[Open in Expo Snack](https://snack.expo.dev/?platform=web&code=import%20React%20from%20'react'%3B%0Aimport%20%7B%20Text%2C%20View%2C%20StyleSheet%20%7D%20from%20'react-native'%3B%0A%0Aexport%20default%20function%20App()%20%7B%0A%20%20return%20(%0A%20%20%20%20%3CView%20style%3D%7Bstyles.container%7D%3E%0A%20%20%20%20%20%20%3CText%3EHello%20World%3C%2FText%3E%0A%20%20%20%20%3C%2FView%3E%0A%20%20)%3B%0A%7D%0A%0Aconst%20styles%20%3D%20StyleSheet.create(%7B%0A%20%20container%3A%20%7B%0A%20%20%20%20flex%3A%201%2C%0A%20%20%20%20justifyContent%3A%20'center'%2C%0A%20%20%20%20alignItems%3A%20'center'%2C%0A%20%20%7D%2C%0A%7D)%3B%0A)
+
+The link opens an online editor and simulator for the same code.

--- a/expo-hello-world/App.js
+++ b/expo-hello-world/App.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import { Text, View, StyleSheet } from 'react-native';
+
+export default function App() {
+  return (
+    <View style={styles.container}>
+      <Text>Hello World</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+});

--- a/expo-hello-world/package.json
+++ b/expo-hello-world/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "expo-hello-world",
+  "version": "1.0.0",
+  "main": "App.js",
+  "private": true,
+  "dependencies": {
+    "expo": "^50.0.0",
+    "react": "^18.2.0",
+    "react-native": "^0.73.0"
+  }
+}


### PR DESCRIPTION
## Summary
- add simple Expo project that prints "Hello World"
- document how to run the demo and view it online in Expo Snack

## Testing
- `node -v`
- `npm -v`


------
https://chatgpt.com/codex/tasks/task_e_6852043a44bc832c959e06dcfd3ab120